### PR TITLE
Replace some MonadBaseControl with MonadUnliftIO

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Tighten the constraint on `runFileLoggingT` and `withChannelLogger` from `MonadBaseControl IO m` to `MonadUnliftIO m`
+* Add `unliftio` dependency
+
 ## 0.3.28.5
 
 * Fix missing module [#1](https://github.com/snoyberg/monad-logger/issues/1)

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ dependencies:
 - mtl
 - bytestring >=0.10.2
 - exceptions >=0.6 && <0.11
+- unliftio
 - unliftio-core
 
 library:


### PR DESCRIPTION
This patch removes some `MonadBaseControl` from the external API, and adds an `unliftio` dependency. I left the instance of `MonadBaseControl` in, however.