### PR TITLE
Adds MFunctor instances for LoggingT, NoLoggingT, and WriterLoggingT

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -31,6 +31,7 @@ dependencies:
 - conduit-extra >=1.1 && <1.4
 - fast-logger >=2.1 && <2.5
 - transformers-base
+- mmorph
 - monad-control >=1.0
 - monad-loops
 - mtl


### PR DESCRIPTION
When working with large transformer stacks I've found [hoist](http://hackage.haskell.org/package/mmorph-1.1.2/docs/Control-Monad-Morph.html#v:hoist) to be extremely useful. This PR adds instances for `MFunctor` to the LoggingT transformers.