### PR TITLE
Export LogLine type synonym

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.3.31
+
+* Export LogLine type synonym
+
 ## 0.3.30
 
 * Added `MonadFail` instances for `LoggingT` and `NoLoggingT`.

--- a/Control/Monad/Logger.hs
+++ b/Control/Monad/Logger.hs
@@ -50,6 +50,7 @@ module Control.Monad.Logger
     , NoLoggingT (..)
     , mapNoLoggingT
     , WriterLoggingT (..)
+    , LogLine
     , execWriterLoggingT
     , runWriterLoggingT
     , mapLoggingT
@@ -407,7 +408,7 @@ instance MonadUnliftIO m => MonadUnliftIO (NoLoggingT m) where
                 withUnliftIO $ \u ->
                 return (UnliftIO (unliftIO u . runNoLoggingT))
 
--- | @since 0.3.28
+-- | @since 0.3.31
 type LogLine = (Loc, LogSource, LogLevel, LogStr)
 
 -- | @since 0.3.28


### PR DESCRIPTION
If the symbol is not exported, you have to look at the source to see what you are working with.

The same applies to `DList`, which is visible from `unWriterLoggingT`, but this would clash with the `dlist` package.