### PR TITLE
Re-export `fromLogStr`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.3.31
+
+* Re-export `fromLogStr` to make implementing custom instances more convenient.
+  [#14](https://github.com/snoyberg/monad-logger/pull/14)
+
 ## 0.3.30
 
 * Added `MonadFail` instances for `LoggingT` and `NoLoggingT`.

--- a/Control/Monad/Logger.hs
+++ b/Control/Monad/Logger.hs
@@ -38,6 +38,7 @@ module Control.Monad.Logger
     -- * Re-export from fast-logger
     , LogStr
     , ToLogStr(..)
+    , fromLogStr
     -- * Helper transformers
     , LoggingT (..)
     , runStderrLoggingT

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        monad-logger
-version:     0.3.30
+version:     0.3.31
 synopsis:    A class of monads which can log messages.
 description: See README and Haddocks at <https://www.stackage.org/package/monad-logger>
 category:    System


### PR DESCRIPTION
Simplifies writing custom instances of `MonadLogger`/`MonadLoggerIO`. Fixes #13.