### PR TITLE
Fix build for lts-9 resolver

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for monad-logger
 
+## 0.3.34
+
+* Fix build for lts-9 resolver
+
 ## 0.3.33
 
 * Export `LogLine` type synonym.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        monad-logger
-version:     0.3.33
+version:     0.3.34
 synopsis:    A class of monads which can log messages.
 description: See README and Haddocks at <https://www.stackage.org/package/monad-logger>
 category:    System


### PR DESCRIPTION
I noticed build for lts-9 resolver is broken. `withRunInIO` was introduced to `unliftio-core` since version `0.1.1.0`, however, only version `0.1.0.0` is available in [lts-9](https://www.stackage.org/lts-9/package/unliftio-core)