### PR TITLE
Use type synonym LogSource consistently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ matrix:
   #- env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
   #  compiler: ": #GHC 7.8.4"
   #  addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.10.3"
-    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  #- env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #  compiler: ": #GHC 7.10.3"
+  #  addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.0.2"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
@@ -92,16 +92,24 @@ matrix:
   #  compiler: ": #stack 8.0.1"
   #  addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-9"
+  - env: BUILD=stack ARGS="--stack-yaml stack-ghc-8.0.2.yaml"
     compiler: ": #stack 8.0.2"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-11"
+  - env: BUILD=stack ARGS="--stack-yaml stack-ghc-8.2.2.yaml"
     compiler: ": #stack 8.2.2"
     addons: {apt: {packages: [libgmp-dev]}}
 
+  - env: BUILD=stack ARGS="--stack-yaml stack-ghc-8.4.4.yaml"
+    compiler: ": #stack 8.4.4"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--stack-yaml stack-ghc-8.6.5.yaml"
+    compiler: ": #stack 8.6.5"
+    addons: {apt: {packages: [libgmp-dev]}}
+
   # Nightly builds are allowed to fail
-  - env: BUILD=stack ARGS="--resolver nightly"
+  - env: BUILD=stack ARGS="--stack-yaml stack-nightly.yaml"
     compiler: ": #stack nightly"
     addons: {apt: {packages: [libgmp-dev]}}
 
@@ -127,21 +135,29 @@ matrix:
   #  compiler: ": #stack 8.0.1 osx"
   #  os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-9"
+  - env: BUILD=stack ARGS="--stack-yaml stack-ghc-8.0.2.yaml"
     compiler: ": #stack 8.0.2 osx"
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-11"
+  - env: BUILD=stack ARGS="--stack-yaml stack-ghc-8.2.2.yaml"
     compiler: ": #stack 8.2.2 osx"
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver nightly"
+  - env: BUILD=stack ARGS="--stack-yaml stack-ghc-8.4.4.yaml"
+    compiler: ": #stack 8.4.4 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--stack-yaml stack-ghc-8.6.5.yaml"
+    compiler: ": #stack 8.6.5 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--stack-yaml stack-nightly.yaml"
     compiler: ": #stack nightly osx"
     os: osx
 
   allow_failures:
   - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
-  - env: BUILD=stack ARGS="--resolver nightly"
+  - env: BUILD=stack ARGS="--stack-yaml stack-nightly.yaml"
 
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it

--- a/Control/Monad/Logger.hs
+++ b/Control/Monad/Logger.hs
@@ -872,19 +872,19 @@ logErrorN = logWithoutLoc "" LevelError
 logOtherN :: MonadLogger m => LogLevel -> Text -> m ()
 logOtherN = logWithoutLoc ""
 
-logDebugNS :: MonadLogger m => Text -> Text -> m ()
+logDebugNS :: MonadLogger m => LogSource -> Text -> m ()
 logDebugNS src = logWithoutLoc src LevelDebug
 
-logInfoNS :: MonadLogger m => Text -> Text -> m ()
+logInfoNS :: MonadLogger m => LogSource -> Text -> m ()
 logInfoNS src = logWithoutLoc src LevelInfo
 
-logWarnNS :: MonadLogger m => Text -> Text -> m ()
+logWarnNS :: MonadLogger m => LogSource -> Text -> m ()
 logWarnNS src = logWithoutLoc src LevelWarn
 
-logErrorNS :: MonadLogger m => Text -> Text -> m ()
+logErrorNS :: MonadLogger m => LogSource -> Text -> m ()
 logErrorNS src = logWithoutLoc src LevelError
 
-logOtherNS :: MonadLogger m => Text -> LogLevel -> Text -> m ()
+logOtherNS :: MonadLogger m => LogSource -> LogLevel -> Text -> m ()
 logOtherNS = logWithoutLoc
 
 #if WITH_CALLSTACK

--- a/stack-ghc-8.0.2.yaml
+++ b/stack-ghc-8.0.2.yaml
@@ -1,0 +1,2 @@
+# Latest for GHC 8.0.x (GHC 8.0.2)
+resolver: lts-9.2

--- a/stack-ghc-8.2.2.yaml
+++ b/stack-ghc-8.2.2.yaml
@@ -1,0 +1,2 @@
+# Latest for GHC 8.2.x (GHC 8.2.2)
+resolver: lts-11.22

--- a/stack-ghc-8.4.4.yaml
+++ b/stack-ghc-8.4.4.yaml
@@ -1,0 +1,2 @@
+# Latest for GHC 8.4.x (GHC 8.4.4)
+resolver: lts-12.26

--- a/stack-ghc-8.6.5.yaml
+++ b/stack-ghc-8.6.5.yaml
@@ -1,0 +1,2 @@
+# Latest for GHC 8.6.x (GHC 8.6.5)
+resolver: lts-14.27

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,0 +1,2 @@
+# Latest for GHC 8.10.x (GHC 8.10.1)
+resolver: nightly-2020-08-08

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,4 @@
-resolver: lts-16.0
+# Latest for GHC 8.8.x (GHC 8.8.3)
+resolver: lts-16.8
+# Required for Windows 10 version 2004, as GHC 8.8.x broken before GHC 8.8.4
+compiler: ghc-8.8.4


### PR DESCRIPTION
Type synonym `LogSource` is already used in the signatures of other functions.

Also bumps `stack.yaml` from `lts-16.0` (GHC 8.8.3) to use the latest GHC 8.8.x version.

Also updates existing CI scripts to use different .yaml files. Drops GHC 7.10.x because network-3.1.2.0 uses GHC language extension TypeApplications introduced in GHC 8.0.

Tested by building on Windows 10 version 2004.