### PR TITLE
Document Loc

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for monad-logger
 
+## 0.3.36
+
+* Document `Loc` []()
+
 ## 0.3.35
 
 * Add Hackage status badge

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 0.3.36
 
-* Document `Loc` []()
+* Document `Loc` [#26](https://github.com/snoyberg/monad-logger/pull/26)
 
 ## 0.3.35
 

--- a/Control/Monad/Logger.hs
+++ b/Control/Monad/Logger.hs
@@ -100,6 +100,7 @@ module Control.Monad.Logger
 #endif
     -- * utilities for defining your own loggers
     , defaultLogStr
+    -- $locDocs
     , Loc (..)
     , defaultLoc
     ) where
@@ -177,6 +178,22 @@ data LogLevel = LevelDebug | LevelInfo | LevelWarn | LevelError | LevelOther Tex
     deriving (Eq, Prelude.Show, Prelude.Read, Ord)
 
 type LogSource = Text
+
+-- $locDocs
+--
+-- === Loc
+--
+-- When @monad-logger@ is compiled with the @template_haskell@ flag set to true (the default), the 'Loc' below is a re-export from the @template-haskell@ package.
+-- When the flag is false, the 'Loc' below is a copy of that data structure defined in @monad-logger@ itself.
+--
+-- If you are making a library that:
+--
+-- * Uses @monad-logger@
+-- * Uses 'Loc' in a type signature
+-- * But doesn't need to depend on @template-haskell@ for other reasons
+--
+-- You can import 'Loc' directly from this package, instead of adding an dependency on @template-haskell@ and importing from there.
+-- This allows users to compile your package in environments that don't support @template-haskell@.
 
 #if WITH_TEMPLATE_HASKELL
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        monad-logger
-version:     0.3.35
+version:     0.3.36
 synopsis:    A class of monads which can log messages.
 description: See README and Haddocks at <https://www.stackage.org/package/monad-logger>
 category:    System


### PR DESCRIPTION
This PR is primarily inspired by https://github.com/yesodweb/persistent/pull/1076. Persistent was importing `Loc` directly from template-haskell and unnecessarily depending on that package, causing issues for users.

This PR documents what I think is the intended usage, importing `Loc` from monad-logger instead. Additionally, I think the documentation around Loc is good for even regular users, since it explains it's a re-export from template-haskell.

I wasn't able to add documentation directly to `Loc` with the standard `-- |`, I'm guessing because `Loc` is a re-export. So I added the documentation directly above the export of `Loc`.