### PR TITLE
Update stack.yaml, for lts-16.12

### DIFF
--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,2 +1,2 @@
-# Latest for GHC 8.10.x (GHC 8.10.1)
-resolver: nightly-2020-08-08
+# Latest for GHC 8.10.x (GHC 8.10.2)
+resolver: nightly-2020-08-30

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,2 @@
-# Latest for GHC 8.8.x (GHC 8.8.3)
-resolver: lts-16.8
-# Required for Windows 10 version 2004, as GHC 8.8.x broken before GHC 8.8.4
-compiler: ghc-8.8.4
+# Latest for GHC 8.8.x (GHC 8.8.4)
+resolver: lts-16.12


### PR DESCRIPTION
`lts-16.12` is for GHC 8.8.4, which works on Windows 10 version 2004.