### PR TITLE
Raise lower bound on base to avoid build failures

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -19,7 +19,7 @@ flags:
     default: true
 
 dependencies:
-- base >= 4.8 && <5
+- base >= 4.11 && <5
 - transformers
 - transformers-compat >=0.3
 - text


### PR DESCRIPTION
… with GHC < 8.4

Fixes #36.