### PR TITLE
Relax upper bound on fast-logger from 3.2 to 3.3

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for monad-logger
 
+## 0.3.40
+
+* Relax `fast-logger` upper bound from 3.2 to 3.3
+
 ## 0.3.39
 
 * Make the previous change backwards compatible with CPP

--- a/package.yaml
+++ b/package.yaml
@@ -29,7 +29,7 @@ dependencies:
 - resourcet >=1.1 && <1.4
 - conduit >=1.0 && <1.4
 - conduit-extra >=1.1 && <1.4
-- fast-logger >=2.1 && <3.2
+- fast-logger >=2.1 && <3.3
 - transformers-base
 - monad-control >=1.0
 - monad-loops


### PR DESCRIPTION
This PR relaxes the `fast-logger` upper bound, per the Stackage issue reported here: https://github.com/commercialhaskell/stackage/issues/6882