### PR TITLE
Alternative instances for LoggingT, NoLoggingT, and WriterLoggingT

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## 0.3.40
 
 * Relax `fast-logger` upper bound from 3.2 to 3.3
+* Add `Alternative` instances for `LoggingT` and `NoLoggingT`
 
 ## 0.3.39
 

--- a/Control/Monad/Logger.hs
+++ b/Control/Monad/Logger.hs
@@ -489,10 +489,6 @@ instance Applicative m => Applicative (WriterLoggingT m) where
   WriterLoggingT mf <*> WriterLoggingT ma = WriterLoggingT $
     fmap (\((f, msgs), (a, msgs')) -> (f a, appendDList msgs msgs')) ((,) <$> mf <*> ma)
 
-instance Alternative m => Alternative (WriterLoggingT m) where
-  empty = WriterLoggingT ((, emptyDList) <$> empty)
-  WriterLoggingT x <|> WriterLoggingT y = WriterLoggingT (x <|> y)
-
 instance Functor m => Functor (WriterLoggingT m) where
   fmap f (WriterLoggingT ma) = WriterLoggingT $
     fmap (\(a, msgs) -> (f a, msgs)) ma
@@ -602,6 +598,7 @@ instance Applicative m => Applicative (LoggingT m) where
     {-# INLINE (<*>) #-}
 #endif
 
+-- @since 0.3.40
 instance (Alternative m) => Alternative (LoggingT m) where
   empty = LoggingT (const empty)
   LoggingT x <|> LoggingT y = LoggingT (\f -> x f <|> y f)

--- a/Control/Monad/Logger.hs
+++ b/Control/Monad/Logger.hs
@@ -389,7 +389,10 @@ logOtherS = [|\src level msg -> monadLoggerLog $(qLocation >>= liftLoc) src (Lev
 --
 -- @since 0.2.4
 newtype NoLoggingT m a = NoLoggingT { runNoLoggingT :: m a }
-  deriving (Functor, Applicative, Alternative, Monad, MonadIO, MonadThrow, MonadCatch, MonadMask, MonadActive, MonadBase b)
+  deriving (
+    Functor, Applicative, Monad, MonadIO, MonadThrow, MonadCatch, MonadMask, MonadActive, MonadBase b
+    , Alternative -- ^ @since 0.3.40
+    )
 
 -- For some reason GND is a fool on GHC 7.10 and older, we have to help it by providing the context explicitly.
 deriving instance MonadResource m => MonadResource (NoLoggingT m)
@@ -598,7 +601,7 @@ instance Applicative m => Applicative (LoggingT m) where
     {-# INLINE (<*>) #-}
 #endif
 
--- @since 0.3.40
+-- | @since 0.3.40
 instance (Alternative m) => Alternative (LoggingT m) where
   empty = LoggingT (const empty)
   LoggingT x <|> LoggingT y = LoggingT (\f -> x f <|> y f)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        monad-logger
-version:     0.3.39
+version:     0.3.40
 synopsis:    A class of monads which can log messages.
 description: See README and Haddocks at <https://www.stackage.org/package/monad-logger>
 category:    System


### PR DESCRIPTION
I wanted to be able to use logging in a monad stack when using parser combinators like [Control.Applicative.Combinators](https://hackage.haskell.org/package/parser-combinators-1.3.0/docs/Control-Applicative-Combinators.html).

I'm not 100% sure the `WriterLoggingT` instance makes sense but the others seem to work fine.