### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for monad-logger
 
+## 0.3.42
+
+* Forward compatibility with `-Wnoncanonical-monad-instances` becoming an error
+
 ## 0.3.41
 
 * Add `MonadAccum` instances for `LoggingT` and `NoLoggingT`

--- a/Control/Monad/Logger.hs
+++ b/Control/Monad/Logger.hs
@@ -113,7 +113,7 @@ import Language.Haskell.TH.Syntax (Lift (lift), Q, Exp, Loc (..), qLocation)
 import Data.Functor ((<$>))
 import Data.Monoid (Monoid)
 
-import Control.Applicative (Alternative (..), Applicative (..), WrappedMonad(..))
+import Control.Applicative (Alternative (..), Applicative (..))
 import Control.Concurrent.Chan (Chan(),writeChan,readChan)
 import Control.Concurrent.STM
 import Control.Concurrent.STM.TBChan
@@ -484,7 +484,6 @@ execWriterLoggingT :: Functor m => WriterLoggingT m a -> m [LogLine]
 execWriterLoggingT ma = snd <$> runWriterLoggingT ma
 
 instance Monad m => Monad (WriterLoggingT m) where
-  return = unwrapMonad . pure
   (WriterLoggingT ma) >>= f = WriterLoggingT $ do
     (a, msgs)   <- ma
     (a', msgs') <- unWriterLoggingT $ f a
@@ -616,7 +615,6 @@ instance (Fail.MonadFail m) => Fail.MonadFail (LoggingT m) where
 #endif
 
 instance Monad m => Monad (LoggingT m) where
-    return = LoggingT . const . return
     LoggingT ma >>= f = LoggingT $ \r -> do
         a <- ma r
         let LoggingT f' = f a

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        monad-logger
-version:     0.3.41
+version:     0.3.42
 synopsis:    A class of monads which can log messages.
 description: See README and Haddocks at <https://www.stackage.org/package/monad-logger>
 category:    System


### PR DESCRIPTION
This appeases the -Wnoncanonical-monad-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return